### PR TITLE
 Add curved walls feature

### DIFF
--- a/importldraw.py
+++ b/importldraw.py
@@ -58,6 +58,7 @@ flattenHierarchy   = False
 useUnofficialParts = True
 useLogoStuds       = False
 instanceStuds      = False
+curvedWalls        = True
 (etc)
 """
 
@@ -187,6 +188,12 @@ class ImportLDrawOps(bpy.types.Operator, ImportHelper):
         default=prefs.get("gapWidth", 0.01)
     )
 
+    curvedWalls = BoolProperty(
+        name="Use curved wall normals",
+        description="Makes surfaces look slightly concave",
+        default=prefs.get("curvedWalls", True)
+    )
+
     linkParts = BoolProperty(
         name="Link identical parts",
         description="Identical parts (same type and colour) share the same mesh",
@@ -261,6 +268,7 @@ class ImportLDrawOps(bpy.types.Operator, ImportHelper):
         box.prop(self, "bevelEdges")
         box.prop(self, "addGaps")
         box.prop(self, "gapsSize")
+        box.prop(self, "curvedWalls")
         box.prop(self, "linkParts")
         box.prop(self, "useUnofficialParts")
 
@@ -290,6 +298,7 @@ class ImportLDrawOps(bpy.types.Operator, ImportHelper):
         ImportLDrawOps.prefs.set("useColourScheme",       self.colourScheme)
         ImportLDrawOps.prefs.set("gaps",                  self.addGaps)
         ImportLDrawOps.prefs.set("gapWidth",              self.gapsSize)
+        ImportLDrawOps.prefs.set("curvedWalls",           self.curvedWalls)
         ImportLDrawOps.prefs.set("linkParts",             self.linkParts)
         ImportLDrawOps.prefs.set("numberNodes",           self.numberNodes)
         ImportLDrawOps.prefs.set("positionObjectOnGroundAtOrigin", self.positionOnGround)
@@ -315,6 +324,7 @@ class ImportLDrawOps(bpy.types.Operator, ImportHelper):
         loadldraw.Options.edgeSplit          = self.smoothParts     # Edge split is appropriate only if we are smoothing
         loadldraw.Options.gaps               = self.addGaps
         loadldraw.Options.gapWidth           = self.gapsSize
+        loadldraw.Options.curvedWalls        = self.curvedWalls
         loadldraw.Options.positionObjectOnGroundAtOrigin = self.positionOnGround
         loadldraw.Options.flattenHierarchy   = self.flatten
         loadldraw.Options.useLogoStuds       = self.useLogoStuds


### PR DESCRIPTION
An option in the user menu gives the user the option to have bricks which look like they have slightly concave walls just like in real life. This especially improves the realism when there are reflections in the build. However, the option results in an increase in render time (about + 25% on my machine).
The look of the curved walls is achieved with standard Cycles group node consisting of only standard nodes that connects into the normal input of the Lego material to give maximum compatibility. The curved look is not implemented in instruction rendering mode as it would increase the rendering times without serving a function.