### PR TITLE
Automatic case sensitivity on importing subfiles

### DIFF
--- a/loadldraw/loadldraw.py
+++ b/loadldraw/loadldraw.py
@@ -664,6 +664,7 @@ class FileSystem:
             else:
                 # Perform a normalized check
                 fullPathName = os.path.join(path, partName.lower())
+                print(fullPathName)
                 if os.path.exists(fullPathName):
                     return fullPathName
 
@@ -678,9 +679,18 @@ class CachedFiles:
     __cache = {}        # Dictionary
 
     def getCached(key):
-        if key in CachedFiles.__cache:
-            return CachedFiles.__cache[key]
-        return None
+        # get the file from the cache associated with the exact key, and if none is
+		# found, try it with case insensitive keys
+        similarKey = None
+        for cacheKey in CachedFiles.__cache:
+            if cacheKey == key:
+                return CachedFiles.__cache[key]
+            elif cacheKey.lower() == key.lower():
+                similarKey = cacheKey
+        if similarKey is not None:
+            return CachedFiles.__cache[similarKey]
+        else:
+            return None		
 
     def addToCache(key, value):
         CachedFiles.__cache[key] = value


### PR DESCRIPTION
It can happen that in a mpd file, the call for a submodel and the definition of a submodel have names that have a different case even though they are meant to be the same. Now, the importer, after first searching for the subfile that matches the case and failing, will look for the name regardless of case. That way, the case sensitivity problem is fixed, and at the same time it is still possible to have multiple submodels with the same name and different case coexist without being filled in with the same model.

An example:

0 FILE main.mpd
1 16 ... submodel1.ldr
1 16 ... SUBMODEL1.LDR
1 16 ... SUBMODEL2.LDR
...
0 FILE submodel1.ldr
...
0 FILE SUBMODEL1.LDR
...
0 FILE submodel2.ldr
...

will be imported with subfiles submodel1.ldrs, SUBMODEL1.LDR and submodel2.ldr in the designated places.