### PR TITLE
Add a grainy texture to slopes

### DIFF
--- a/ImportLDrawPreferences.ini
+++ b/ImportLDrawPreferences.ini
@@ -1,0 +1,20 @@
+[importldraw]
+ldrawdirectory = C:\LDraw
+scale = 0.019999999552965164
+resolution = Standard
+smoothshading = True
+usecolourscheme = lgeo
+gaps = True
+gapwidth = 0.003000000026077032
+linkparts = True
+numbernodes = True
+positionobjectongroundatorigin = True
+flattenhierarchy = False
+useunofficialparts = True
+uselogostuds = True
+instancestuds = False
+resolvenormals = guess
+beveledges = True
+uselook = normal
+curvedwalls = True
+

--- a/studs/stud2-logo3.dat
+++ b/studs/stud2-logo3.dat
@@ -9,4 +9,4 @@
 0 !HISTORY 2016-06-06 [tnelson] Created 2016-06-06
 
 1 16 0 0 0 1 0 0 0 0.95 0 0 0 1 stud2-copy.dat
-1 16 0 0 0 1 0 0 0 1 0 0 0 1 logo3.dat
+1 16 0 0 0 0.7 0 0 0 0.7 0 0 0 0.7 logo3.dat

--- a/studs/stud2-logo4.dat
+++ b/studs/stud2-logo4.dat
@@ -9,4 +9,4 @@
 0 !HISTORY 2016-06-06 [tnelson] Created 2016-06-06
 
 1 16 0 0 0 1 0 0 0 0.95 0 0 0 1 stud2-copy.dat
-1 16 0 0 0 1 0 0 0 1 0 0 0 1 logo4.dat
+1 16 0 0 0 0.7 0 0 0 0.7 0 0 0 0.7 logo4.dat

--- a/studs/stud2-logo5.dat
+++ b/studs/stud2-logo5.dat
@@ -9,4 +9,4 @@
 0 !HISTORY 2016-06-06 [tnelson] Created 2016-06-06
 
 1 16 0 0 0 1 0 0 0 0.95 0 0 0 1 stud2-copy.dat
-1 16 0 0 0 1 0 0 0 1 0 0 0 1 logo5.dat
+1 16 0 0 0 0.7 0 0 0 0.7 0 0 0 0.7 logo5.dat


### PR DESCRIPTION
- Adds a bumpy, grainy texture to the sloped faces of bricks which have the same texture in real life as mentioned in  #1 . Requires some hard coded lists of which parts to consider, but all in all it is done in the most automatic way possible that doesn't require to specify each and every face that needs the texture. These are the results after some fine tuning to find the balance between a subtle yet clear effect, and likely some more tweaking can be done:
![slopetextures](https://user-images.githubusercontent.com/10909554/44047892-204ecc56-9f30-11e8-97bb-6c6c1d70f148.png)

- Shrink the logos in open studs to be more true to real life, as mentioned in #18 