### PR TITLE
Add option to disable subsurface

### DIFF
--- a/importldraw.py
+++ b/importldraw.py
@@ -194,6 +194,12 @@ class ImportLDrawOps(bpy.types.Operator, ImportHelper):
         default=prefs.get("curvedWalls", True)
     )
 
+    addSubsurface: BoolProperty(
+        name="Add subsurface",
+        description="Adds subsurface to principled shader",
+        default=prefs.get("addSubsurface", True)
+    )
+
     importCameras: BoolProperty(
         name="Import cameras",
         description="Import camera definitions (from models authored in LeoCAD)",
@@ -301,6 +307,7 @@ class ImportLDrawOps(bpy.types.Operator, ImportHelper):
         box.prop(self, "colourScheme", expand=True)
         box.prop(self, "resPrims", expand=True)
         box.prop(self, "smoothParts")
+        box.prop(self, "addSubsurface")
         box.prop(self, "bevelEdges")
         box.prop(self, "bevelWidth")
         box.prop(self, "addGaps")
@@ -328,6 +335,7 @@ class ImportLDrawOps(bpy.types.Operator, ImportHelper):
         ImportLDrawOps.prefs.set("scale",                 self.importScale)
         ImportLDrawOps.prefs.set("resolution",            self.resPrims)
         ImportLDrawOps.prefs.set("smoothShading",         self.smoothParts)
+        ImportLDrawOps.prefs.set("addSubsurface",         self.addSubsurface)
         ImportLDrawOps.prefs.set("bevelEdges",            self.bevelEdges)
         ImportLDrawOps.prefs.set("bevelWidth",            self.bevelWidth)
         ImportLDrawOps.prefs.set("useLook",               self.look)
@@ -369,6 +377,7 @@ class ImportLDrawOps(bpy.types.Operator, ImportHelper):
         loadldraw.Options.gaps               = self.addGaps
         loadldraw.Options.gapWidth           = self.gapsSize
         loadldraw.Options.curvedWalls        = self.curvedWalls
+        loadldraw.Options.addSubsurface      = self.addSubsurface
         loadldraw.Options.importCameras      = self.importCameras
         loadldraw.Options.positionObjectOnGroundAtOrigin = self.positionOnGround
         loadldraw.Options.flattenHierarchy   = self.flatten

--- a/loadldraw/loadldraw.py
+++ b/loadldraw/loadldraw.py
@@ -1985,8 +1985,9 @@ class BlenderMaterials:
     def __nodePrincipled(nodes, subsurface, sub_rad, metallic, roughness, clearcoat, clearcoat_roughness, ior, transmission, x, y):
         node = nodes.new('ShaderNodeBsdfPrincipled')
         node.location = x, y
-        node.inputs['Subsurface'].default_value = subsurface
-        node.inputs['Subsurface Radius'].default_value = mathutils.Vector( (sub_rad, sub_rad, sub_rad) )
+        if Options.addSubsurface:
+            node.inputs['Subsurface'].default_value = subsurface
+            node.inputs['Subsurface Radius'].default_value = mathutils.Vector( (sub_rad, sub_rad, sub_rad) )
         node.inputs['Metallic'].default_value = metallic
         node.inputs['Roughness'].default_value = roughness
         node.inputs['Clearcoat'].default_value = clearcoat
@@ -2652,7 +2653,8 @@ class BlenderMaterials:
                     node_main = BlenderMaterials.__nodePrincipled(group.nodes, 0.05, 0.05, 0.0, 0.1, 0.0, 0.0, 1.45, 0.0, 0, 0)
                     output_name = 'BSDF'
                     color_name = 'Base Color'
-                    group.links.new(node_input.outputs['Color'],        node_main.inputs['Subsurface Color'])
+                    if Options.addSubsurface:
+                        group.links.new(node_input.outputs['Color'],        node_main.inputs['Subsurface Color'])
                 else:
                     node_main = BlenderMaterials.__nodeDielectric(group.nodes, 0.2, 0.1, 0.0, 1.46, 0, 0)
                     output_name = 'Shader'
@@ -2854,7 +2856,8 @@ class BlenderMaterials:
 
             if BlenderMaterials.usePrincipledShader:
                 node_main = BlenderMaterials.__nodePrincipled(group.nodes, 1.0, 0.05, 0.0, 0.5, 0.0, 0.03, 1.45, 0.0, -242, 154+240)
-                group.links.new(node_input.outputs['Color'],     node_main.inputs['Subsurface Color'])
+                if Options.addSubsurface:
+                    group.links.new(node_input.outputs['Color'],     node_main.inputs['Subsurface Color'])
                 group.links.new(node_input.outputs['Color'],     node_emit.inputs['Color'])
                 main_colour = 'Base Color'
             else:
@@ -2933,7 +2936,8 @@ class BlenderMaterials:
                 group.links.new(node_sep_hsv.outputs['S'], node_com_hsv.inputs['S'])
                 group.links.new(node_sep_hsv.outputs['V'], node_multiply.inputs[0])
                 group.links.new(node_com_hsv.outputs['Color'], node_principled.inputs['Base Color'])
-                group.links.new(node_com_hsv.outputs['Color'], node_principled.inputs['Subsurface Color'])
+                if Options.addSubsurface:
+                    group.links.new(node_com_hsv.outputs['Color'], node_principled.inputs['Subsurface Color'])
                 group.links.new(node_tex_coord.outputs['Object'], node_tex_wave.inputs['Vector'])
                 group.links.new(node_tex_wave.outputs['Fac'], node_color_ramp.inputs['Fac'])
                 group.links.new(node_color_ramp.outputs['Color'], node_multiply.inputs[1])
@@ -3103,7 +3107,8 @@ class BlenderMaterials:
                 node_mix = BlenderMaterials.__nodeMix(group.nodes, 0.5, 65, -40)
 
                 group.links.new(node_input.outputs['Color'], node_principled.inputs['Base Color'])
-                group.links.new(node_input.outputs['Color'], node_principled.inputs['Subsurface Color'])
+                if Options.addSubsurface:
+                    group.links.new(node_input.outputs['Color'], node_principled.inputs['Subsurface Color'])
                 group.links.new(node_input.outputs['Normal'], node_principled.inputs['Normal'])
                 group.links.new(node_input.outputs['Normal'], node_translucent.inputs['Normal'])
                 group.links.new(node_principled.outputs[0], node_mix.inputs[1])


### PR DESCRIPTION
Add option to disable subsurface so that baking diffuse textures doesn't just produce an all black result.

If there is a subsurface value set in a material, when the texture is baked it will return black. I've added the option to disable the addition of subsurface on materials. Subsurface will still be added by default.