### PR TITLE
Cleaner stud outlines in instruction look

### DIFF
--- a/loadldraw/loadldraw.py
+++ b/loadldraw/loadldraw.py
@@ -4055,8 +4055,8 @@ def setupLineset(lineset, thickness, group):
     # Use square caps
     lineset.linestyle.caps = 'SQUARE'       # Can be 'ROUND', 'BUTT', or 'SQUARE'
 
-    # Draw inside the edge of the object
-    lineset.linestyle.thickness_position = 'INSIDE'
+    # Draw centered on the edge of the object
+    lineset.linestyle.thickness_position = 'CENTER'
 
     # Set Thickness
     lineset.linestyle.thickness = thickness


### PR DESCRIPTION
Improve intersection of lines, mostly shows up on studs and overdraw at corners. 


| Before | After |
|--------|--------|
| <img width="245" height="244" alt="image" src="https://github.com/user-attachments/assets/b8710fc4-dc6a-4caf-bf0e-f4190dfb126f" />  | <img width="244" height="244" alt="image" src="https://github.com/user-attachments/assets/22c78b11-49ae-4d79-850e-b8d82cfddf8a" /> | 
| <img width="1120" height="448" alt="image" src="https://github.com/user-attachments/assets/21b9ecd0-7ced-47d9-b2f4-42483c7711e6" /> |  <img width="1120" height="448" alt="image" src="https://github.com/user-attachments/assets/36590bf4-30b7-4eb8-b79e-689c6394afcb" /> |



Only tested with single parts